### PR TITLE
feat: add LDevice select on create DataSet (#7)

### DIFF
--- a/editors/dataset/data-set-editor.spec.ts
+++ b/editors/dataset/data-set-editor.spec.ts
@@ -32,6 +32,46 @@ describe('DataSet editor component', () => {
     window.addEventListener('oscd-edit-v2', editEvent);
   });
 
+  it('allows to add a new empty DataSet element directly if only one LDevice is available', async () => {
+    // Prepare document to have IED with only one LDevice
+    const copyDoc = doc.cloneNode(true) as XMLDocument;
+    const ied = copyDoc.querySelector('IED[name="IED"]')!;
+
+    const lDevices = ied.querySelectorAll(
+      ':scope > AccessPoint > Server > LDevice'
+    );
+    lDevices.forEach(ld => {
+      if (ld.getAttribute('inst') !== 'ldInst1') {
+        ld.remove();
+      }
+    });
+
+    editor = await fixture(
+      html`<data-set-editor .doc="${copyDoc}"></data-set-editor>`
+    );
+
+    // should add new DataSet element to the only available LDevice without opening the LDevice select dialog
+    const addDataSetListItem = editor.shadowRoot
+      ?.querySelector('action-list')
+      ?.shadowRoot?.querySelector('md-list:nth-child(2)')
+      ?.querySelector('md-list-item') as HTMLElement;
+    expect(addDataSetListItem).to.exist;
+    addDataSetListItem.click();
+
+    await editor.updateComplete;
+    await Promise.resolve();
+
+    expect(editEvent).to.have.been.calledOnce;
+
+    const insert = editEvent.args[0][0].detail.edit;
+
+    expect(insert).to.satisfy(isInsert);
+    expect(insert.parent.tagName).to.equal('LN0');
+    expect(insert.node.tagName).to.equal('DataSet');
+    expect(insert.node.getAttribute('name')).to.equal('newDataSet_001');
+    expect(insert.node.children.length).to.equal(0);
+  });
+
   it('allows to add a new empty DataSet element to a selected LDevice if multiple LDevices are available', async () => {
     // should open LDevice select dialog
     const addDataSetListItem = editor.shadowRoot

--- a/editors/dataset/data-set-editor.spec.ts
+++ b/editors/dataset/data-set-editor.spec.ts
@@ -21,16 +21,51 @@ const doc = new DOMParser().parseFromString(dataSetDoc, 'application/xml');
 
 describe('DataSet editor component', () => {
   let editEvent: SinonSpy;
+  let editor: DataSetEditor;
 
   beforeEach(async () => {
-    await fixture(html`<data-set-editor .doc="${doc}"></data-set-editor>`);
+    editor = await fixture(
+      html`<data-set-editor .doc="${doc}"></data-set-editor>`
+    );
 
     editEvent = spy();
     window.addEventListener('oscd-edit-v2', editEvent);
   });
 
-  it('allows to add a new empty DataSet element', async () => {
-    await sendMouse({ type: 'click', position: [760, 100] });
+  it('allows to add a new empty DataSet element to a selected LDevice if multiple LDevices are available', async () => {
+    // should open LDevice select dialog
+    const addDataSetListItem = editor.shadowRoot
+      ?.querySelector('action-list')
+      ?.shadowRoot?.querySelector('md-list:nth-child(2)')
+      ?.querySelector('md-list-item') as HTMLElement;
+    expect(addDataSetListItem).to.exist;
+    addDataSetListItem.click();
+
+    await editor.updateComplete;
+    await Promise.resolve();
+
+    // get the dialog
+    const dialog = editor.lDeviceSelectDialog;
+
+    // get the second lDevice radio button
+    const radio = dialog
+      .querySelector('md-list')
+      ?.querySelector('md-list-item:nth-child(2)')!
+      .querySelector('md-radio') as HTMLElement;
+
+    // select second lDevice as target
+    radio.click();
+    await editor.updateComplete;
+    await Promise.resolve();
+
+    // click the "Select" button
+    const selectBtn = dialog.querySelector(
+      'md-text-button.do.picker.save'
+    ) as HTMLElement;
+    selectBtn.click();
+
+    await editor.updateComplete;
+    await Promise.resolve();
 
     expect(editEvent).to.have.been.calledOnce;
 
@@ -61,6 +96,7 @@ describe('DataSet editor component', () => {
 
     const actionList = (el as DataSetEditor).selectionList;
     expect(actionList).to.exist;
+    actionList.items;
     expect(actionList.searchValue).to.equal('IED1');
   });
 });

--- a/editors/dataset/data-set-editor.ts
+++ b/editors/dataset/data-set-editor.ts
@@ -129,6 +129,15 @@ export class DataSetEditor extends ScopedElementsMixin(LitElement) {
                 );
                 if (lDevices.length === 0) {
                   // LDevice does not exist, cannot create DataSet
+                  const iedName = ied.getAttribute('name');
+                  const reason = 'it has no LDevice element';
+                  this.dispatchEvent(
+                    newLogEvent({
+                      title: 'Could not create DataSet',
+                      message: `The DataSet could not be created in IED '${iedName}' because ${reason}.`,
+                      kind: 'warning',
+                    })
+                  );
                 } else if (lDevices.length === 1) {
                   // only one LDevice, create DataSet directly
                   const selectedLDevice = lDevices[0];

--- a/editors/dataset/data-set-editor.ts
+++ b/editors/dataset/data-set-editor.ts
@@ -227,14 +227,15 @@ export class DataSetEditor extends ScopedElementsMixin(LitElement) {
   }
 
   private renderLDeviceSelectDialog(): TemplateResult {
-    return html`
-    <md-dialog id="ldevice-select">
+    return html` <md-dialog id="ldevice-select">
       <div slot="headline">Select LDevice</div>
 
-        <div slot="content">
-          <p style="color: var(--mdc-theme-on-surface, #333); font-size: 0.95em;">Choose the LDevice to which the new DataSet will be added.</p>
-          <form>
-            <md-list role="radiogroup">
+      <div slot="content">
+        <p style="color: var(--mdc-theme-on-surface, #333); font-size: 0.95em;">
+          Choose the LDevice to which the new DataSet will be added.
+        </p>
+        <form>
+          <md-list role="radiogroup">
             ${this.lDevices.map(
               (ld, i) => html`
                 <md-list-item>
@@ -250,19 +251,22 @@ export class DataSetEditor extends ScopedElementsMixin(LitElement) {
                 </md-list-item>
               `
             )}
-          </form>
-        </div>
+          </md-list>
+        </form>
+      </div>
 
-        <div slot="actions">
-          <md-text-button
-            @click=${() => this.lDeviceSelectDialog?.close()}
-          >Close</md-text-button>
-          <md-text-button 
-            class="do picker save"
-            @click=${() => this.handleLDeviceSelect()}
-          >Select<md-icon slot="icon">check</md-icon></md-text-button>
-        </div>
-      </md-dialog>`;
+      <div slot="actions">
+        <md-text-button @click=${() => this.lDeviceSelectDialog?.close()}
+          >Close</md-text-button
+        >
+        <md-text-button
+          class="do picker save"
+          ?disabled=${!this.selectedLDevice}
+          @click=${() => this.handleLDeviceSelect()}
+          >Select<md-icon slot="icon">check</md-icon></md-text-button
+        >
+      </div>
+    </md-dialog>`;
   }
 
   private selectLDevice(ld: Element | null): void {

--- a/editors/dataset/data-set-editor.ts
+++ b/editors/dataset/data-set-editor.ts
@@ -124,7 +124,6 @@ export class DataSetEditor extends ScopedElementsMixin(LitElement) {
               icon: 'playlist_add',
               callback: () => {
                 this.selectedIed = ied;
-                // this.lDeviceSelectDialog?.show()
                 const lDevices = ied.querySelectorAll(
                   ':scope > AccessPoint > Server > LDevice'
                 );

--- a/editors/dataset/data-set-editor.ts
+++ b/editors/dataset/data-set-editor.ts
@@ -18,15 +18,26 @@ import {
   removeDataSet,
 } from '@openenergytools/scl-lib';
 
-import { DataSetElementEditor } from './data-set-element-editor.js';
-
+import { MdDialog } from '@scopedelement/material-web/dialog/MdDialog.js';
+import { MdIcon } from '@scopedelement/material-web/icon/MdIcon.js';
+import { MdTextButton } from '@scopedelement/material-web/button/MdTextButton.js';
+import { MdRadio } from '@scopedelement/material-web/radio/radio.js';
+import { MdList } from '@scopedelement/material-web/list/MdList.js';
+import { MdListItem } from '@scopedelement/material-web/list/MdListItem.js';
 import { pathIdentity, styles } from '../../foundation.js';
+import { DataSetElementEditor } from './data-set-element-editor.js';
 
 export class DataSetEditor extends ScopedElementsMixin(LitElement) {
   static scopedElements = {
     'action-list': ActionList,
+    'md-text-button': MdTextButton,
     'data-set-element-editor': DataSetElementEditor,
     'md-outlined-button': MdOutlinedButton,
+    'md-dialog': MdDialog,
+    'md-icon': MdIcon,
+    'md-radio': MdRadio,
+    'md-list': MdList,
+    'md-list-item': MdListItem,
   };
 
   /** The document being edited as provided to plugins by [[`OpenSCD`]]. */
@@ -42,12 +53,23 @@ export class DataSetEditor extends ScopedElementsMixin(LitElement) {
   @state()
   selectedDataSet?: Element;
 
+  @state()
+  lDevices: Element[] = []; // lDevices of the currently selected IED, used for the LDevice select dialog
+
+  @state()
+  selectedLDevice: Element | null = null;
+
+  @state()
+  selectedIed: Element | null = null;
+
   @query('.selectionlist') selectionList!: ActionList;
 
   @query('.change.scl.element') selectDataSetButton!: MdOutlinedButton;
 
   @query('data-set-element-editor')
   dataSetElementEditor!: DataSetElementEditor;
+
+  @query('#ldevice-select') lDeviceSelectDialog!: MdDialog;
 
   /** Resets selected DataSet, if not existing in new doc 
   update(props: Map<string | number | symbol, unknown>): void {
@@ -101,28 +123,22 @@ export class DataSetEditor extends ScopedElementsMixin(LitElement) {
             {
               icon: 'playlist_add',
               callback: () => {
-                const insertDataSet = createDataSet(ied);
-                if (insertDataSet) {
-                  this.dispatchEvent(
-                    newEditEvent(insertDataSet, { title: `Create New DataSet` })
-                  );
+                this.selectedIed = ied;
+                // this.lDeviceSelectDialog?.show()
+                const lDevices = ied.querySelectorAll(
+                  ':scope > AccessPoint > Server > LDevice'
+                );
+                if (lDevices.length === 0) {
+                  // LDevice does not exist, cannot create DataSet
+                } else if (lDevices.length === 1) {
+                  // only one LDevice, create DataSet directly
+                  const selectedLDevice = lDevices[0];
+                  this.createDataSet(ied, selectedLDevice);
                 } else {
-                  const iedName = ied.getAttribute('name');
-                  let reason: string;
-                  const anyLn = ied.querySelector('LN0, LN');
-                  if (!anyLn) {
-                    reason = 'it has no LN0 or LN element';
-                  } else {
-                    reason = 'an unknown validation error occurred';
-                  }
-
-                  this.dispatchEvent(
-                    newLogEvent({
-                      title: 'Could not create DataSet',
-                      message: `The DataSet could not be created in IED '${iedName}' because ${reason}.`,
-                      kind: 'warning',
-                    })
-                  );
+                  // multiple LDevices, show select dialog
+                  this.selectedLDevice = null;
+                  this.lDevices = Array.from(lDevices);
+                  this.lDeviceSelectDialog?.show();
                 }
               },
             },
@@ -170,6 +186,36 @@ export class DataSetEditor extends ScopedElementsMixin(LitElement) {
     ></action-list>`;
   }
 
+  private createDataSet(ied: Element, targetLDevice: Element): void {
+    if (!targetLDevice) return;
+    const ln0 = targetLDevice.querySelector(':scope > LN0');
+    if (!ln0) return;
+
+    const insertDataSet = createDataSet(ln0);
+    if (insertDataSet) {
+      this.dispatchEvent(
+        newEditEvent(insertDataSet, { title: `Create New DataSet` })
+      );
+    } else {
+      const iedName = ied.getAttribute('name');
+      let reason: string;
+      const anyLn = ied.querySelector('LN0, LN');
+      if (!anyLn) {
+        reason = 'it has no LN0 or LN element';
+      } else {
+        reason = 'an unknown validation error occurred';
+      }
+
+      this.dispatchEvent(
+        newLogEvent({
+          title: 'Could not create DataSet',
+          message: `The DataSet could not be created in IED '${iedName}' because ${reason}.`,
+          kind: 'warning',
+        })
+      );
+    }
+  }
+
   private renderToggleButton(): TemplateResult {
     return html`<md-outlined-button
       class="change scl element"
@@ -181,12 +227,61 @@ export class DataSetEditor extends ScopedElementsMixin(LitElement) {
     >`;
   }
 
+  private renderLDeviceSelectDialog(): TemplateResult {
+    return html`
+    <md-dialog id="ldevice-select">
+      <div slot="headline">Select LDevice</div>
+
+        <div slot="content">
+          <p style="color: var(--mdc-theme-on-surface, #333); font-size: 0.95em;">Choose the LDevice to which the new DataSet will be added.</p>
+          <form>
+            <md-list role="radiogroup">
+            ${this.lDevices.map(
+              (ld, i) => html`
+                <md-list-item>
+                  <md-radio
+                    id="ldevice${i}"
+                    name="ldevice"
+                    value="${ld.getAttribute('inst')}"
+                    ?checked=${this.selectedLDevice?.getAttribute('inst') ===
+                    ld.getAttribute('inst')}
+                    @change=${() => this.selectLDevice(ld)}
+                  ></md-radio>
+                  <label for="ldevice${i}">${ld.getAttribute('inst')}</label>
+                </md-list-item>
+              `
+            )}
+          </form>
+        </div>
+
+        <div slot="actions">
+          <md-text-button
+            @click=${() => this.lDeviceSelectDialog?.close()}
+          >Close</md-text-button>
+          <md-text-button 
+            class="do picker save"
+            @click=${() => this.handleLDeviceSelect()}
+          >Select<md-icon slot="icon">check</md-icon></md-text-button>
+        </div>
+      </md-dialog>`;
+  }
+
+  private selectLDevice(ld: Element | null): void {
+    this.selectedLDevice = ld;
+  }
+
+  private handleLDeviceSelect(): void {
+    this.lDeviceSelectDialog?.close();
+    if (!this.selectedLDevice || !this.selectedIed) return;
+    this.createDataSet(this.selectedIed, this.selectedLDevice);
+  }
+
   render(): TemplateResult {
     if (!this.doc) return html`<div>No SCL loaded</div>`;
 
     return html`${this.renderToggleButton()}
       <div class="section">
-        ${this.renderSelectionList()}${this.renderElementEditorContainer()}
+        ${this.renderSelectionList()}${this.renderElementEditorContainer()}${this.renderLDeviceSelectDialog()}
       </div>`;
   }
 


### PR DESCRIPTION
Adds a selection dialog when multiple LDevices exist and creates the DataSet in LN0 of the chosen LDevice. Default behavior is unchanged for single-LDevice IEDs

<img width="2553" height="881" alt="image" src="https://github.com/user-attachments/assets/6f668da5-c907-44fd-89f9-7fcebd718abb" />
